### PR TITLE
some improvements to testing

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -70,7 +70,9 @@ functions:
   upload-test-results:
     - command: attach.xunit_results
       params:
-        file: src/build/test-results/test/TEST-*.xml
+        files:
+          - src/build/test-results/test/TEST-*.xml
+          - src/build/test-results/integrationTest/TEST-*.xml
 
   cleanup:
     - command: subprocess.exec
@@ -107,7 +109,21 @@ tasks:
           args:
             - static-checks.sh
 
-  - name: run-tests
+  - name: run-unit-tests
+    type: test
+    tags:
+      - pr
+    commands:
+      - command: subprocess.exec
+        params:
+          working_dir: src
+          binary: bash
+          add_to_path:
+            - .evergreen
+          args:
+            - run-unit-tests.sh
+
+  - name: run-integration-tests
     type: test
     tags:
       - pr
@@ -120,7 +136,7 @@ tasks:
           add_to_path:
             - .evergreen
           args:
-            - run-tests.sh
+            - run-integration-tests.sh
 
 ########################################
 #              Axes                    #
@@ -170,6 +186,14 @@ buildvariants:
     tasks:
       - name: static-analysis
 
+  - name: unit-tests
+    tags:
+      - pr
+    display_name: "Unit Tests"
+    run_on: rhel80-medium
+    tasks:
+      - name: run-unit-tests
+
   - matrix_name: mongo-hibernate
     matrix_spec: { mongo-version: "*", topology: "*", os: "*" }
 
@@ -177,4 +201,4 @@ buildvariants:
     tags:
       - pr
     tasks:
-      - name: run-tests
+      - name: run-integration-tests

--- a/.evergreen/run-integration-tests.sh
+++ b/.evergreen/run-integration-tests.sh
@@ -9,8 +9,10 @@ set -o errexit  # Exit the script with error if any of the commands fail
 
 source java-config.sh
 
-echo "mongo-hibernate: static checking ..."
+echo "mongo-hibernate: running integration tests ..."
+
+echo "MongoDB version: ${MONGODB_VERSION}; topology: ${TOPOLOGY}"
 
 ./gradlew -version
 
-./gradlew --info -x test -x integrationTest clean check compileJava
+./gradlew -PjavaVersion=${JAVA_VERSION} --stacktrace --info --continue clean integrationTest

--- a/.evergreen/run-unit-tests.sh
+++ b/.evergreen/run-unit-tests.sh
@@ -9,9 +9,7 @@ set -o errexit  # Exit the script with error if any of the commands fail
 
 source java-config.sh
 
-echo "mongo-hibernate: running tests ..."
-
-echo "MongoDB version: ${MONGODB_VERSION}; topology: ${TOPOLOGY}"
+echo "mongo-hibernate: running unit tests ..."
 
 ./gradlew -version
 

--- a/README.md
+++ b/README.md
@@ -37,8 +37,24 @@ To check whether any format violation exists, run `spotlessCheck` gradle task. I
 
 Both plugins are enabled on gradle's `compileJava` task.
 
-## References
+### Testing
 
+Per best practice, we maintain separate directories for unit and integration testings:
+
+- [unit test](src/test)
+- [integration test](src/integrationTest)
+
+Integration tests will connect to a MongoDB deployment. You may change the default [MongoDB connection string](https://www.mongodb.com/docs/manual/reference/connection-string/) configured as below at [hibernate.properties](src/integrationTest/resources/hibernate.properties):
+
+```properties
+jakarta.persistence.jdbc.url=mongodb://localhost/mongo-hibernate-test?directConnection=false
+```
+
+### CI/CD
+An internal CI/CD pipeline is based on an open-source project [evergreen](https://github.com/evergreen-ci/evergreen), a distributed continuous integration system from MongoDB. The corresponding evergreen configuration resources reside in a [.evergreen](/.evergreen) directory under the project root folder.
+
+## References
+It would be highly helpful to refer to the following awesome articles or resources when need arises:
 - [An Introduction to Hibernate 6](https://docs.jboss.org/hibernate/orm/6.6/introduction/html_single/Hibernate_Introduction.html)
 - [A Guide to Hibernate Query Language](https://docs.jboss.org/hibernate/orm/6.6/querylanguage/html_single/Hibernate_Query_Language.html)
 - [Hibernate User Guide](https://docs.jboss.org/hibernate/orm/6.6/userguide/html_single/Hibernate_User_Guide.html)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,23 +26,6 @@ repositories {
     mavenCentral()
 }
 
-dependencies {
-    testImplementation(libs.junit.jupiter)
-    testImplementation(libs.logback.classic)
-    testImplementation(libs.mockito.junit.jupiter)
-
-    testRuntimeOnly(libs.junit.platform.launcher)
-
-    errorprone(libs.nullaway)
-    api(libs.jspecify)
-
-    errorprone(libs.google.errorprone.core)
-
-    implementation(libs.hibernate.core)
-    implementation(libs.mongo.java.driver.sync)
-    implementation(libs.sl4j.api)
-}
-
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(17)
@@ -52,6 +35,40 @@ java {
 tasks.named<Test>("test") {
     useJUnitPlatform()
 }
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// Integration Tests
+
+sourceSets {
+    create("integrationTest") {
+        compileClasspath += sourceSets.main.get().output
+        runtimeClasspath += sourceSets.main.get().output
+    }
+}
+
+val integrationTestImplementation by configurations.getting {
+    extendsFrom(configurations.implementation.get())
+}
+val integrationTestRuntimeOnly: Configuration by configurations.getting
+
+configurations["integrationTestRuntimeOnly"].extendsFrom(configurations.runtimeOnly.get())
+
+val integrationTest = task<Test>("integrationTest") {
+    description = "Runs integration tests."
+    group = "verification"
+
+    testClassesDirs = sourceSets["integrationTest"].output.classesDirs
+    classpath = sourceSets["integrationTest"].runtimeClasspath
+    shouldRunAfter("test")
+
+    useJUnitPlatform()
+
+    testLogging {
+        events("passed")
+    }
+}
+
+tasks.check { dependsOn(integrationTest) }
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Static Analysis Tasks
@@ -83,5 +100,28 @@ tasks.withType<JavaCompile>().configureEach {
 tasks.compileJava {
     // The check defaults to a warning, bump it up to an error for the main sources
     options.errorprone.error("NullAway")
+}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// Dependencies
+
+dependencies {
+    testImplementation(libs.junit.jupiter)
+    testImplementation(libs.logback.classic)
+    testImplementation(libs.mockito.junit.jupiter)
+
+    testRuntimeOnly(libs.junit.platform.launcher)
+
+    integrationTestImplementation(libs.junit.jupiter)
+    integrationTestRuntimeOnly(libs.junit.platform.launcher)
+
+    errorprone(libs.nullaway)
+    api(libs.jspecify)
+
+    errorprone(libs.google.errorprone.core)
+
+    implementation(libs.hibernate.core)
+    implementation(libs.mongo.java.driver.sync)
+    implementation(libs.sl4j.api)
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,17 +2,17 @@
 # https://docs.gradle.org/current/userguide/platforms.html#sub::toml-dependencies-format
 
 [versions]
-junit-jupiter = "5.11.3"
+junit-jupiter = "5.11.4"
 spotless = "6.25.0"
 palantir = "2.50.0"
 errorprone = "4.1.0"
 google-errorprone-core = "2.36.0"
-nullaway = "0.12.1"
+nullaway = "0.12.2"
 jspecify = "1.0.0"
-hibernate-core = "6.6.3.Final"
+hibernate-core = "6.6.4.Final"
 mongo-java-driver-sync = "5.2.1"
 slf4j-api = "2.0.16"
-logback-classic = "1.5.12"
+logback-classic = "1.5.15"
 mockito = "5.14.2"
 
 [libraries]

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
1) separate unit and integration testing (as per https://docs.gradle.org/current/userguide/java_testing.html#sec:configuring_java_integration_tests)
2) tweak evergreen configs to apply mongo-orchestration only for integrationTests
3) added global config to set 'smart-null' as the default mock answer
4) update README.md regarding testing and evergreen
5) minor dependency versions bumping
6) gradle upgrade from 8.10.2 to 8.12