### PR TITLE
experiment keeping from setting if insertion field value is null

### DIFF
--- a/src/integrationTest/java/com/mongodb/hibernate/BasicInsertionTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/BasicInsertionTests.java
@@ -84,7 +84,6 @@ class BasicInsertionTests {
                 {
                     _id: 1,
                     title: "War and Peace",
-                    author: null,
                     publishYear: 1867
                 }""");
         assertCollectionContainsOnly(expectedDocument);

--- a/src/main/java/com/mongodb/hibernate/jdbc/MongoPreparedStatement.java
+++ b/src/main/java/com/mongodb/hibernate/jdbc/MongoPreparedStatement.java
@@ -270,7 +270,13 @@ final class MongoPreparedStatement extends MongoStatement implements PreparedSta
     private static void parseParameters(BsonDocument command, List<Consumer<BsonValue>> parameterValueSetters) {
         for (var entry : command.entrySet()) {
             if (isParameterMarker(entry.getValue())) {
-                parameterValueSetters.add(entry::setValue);
+                parameterValueSetters.add(value -> {
+                    if (value.getBsonType() == BsonType.NULL) {
+                        command.remove(entry.getKey());
+                    } else {
+                        entry.setValue(value);
+                    }
+                });
             } else if (entry.getValue().getBsonType().isContainer()) {
                 parseParameters(entry.getValue(), parameterValueSetters);
             }


### PR DESCRIPTION
seems pretty easy to achieve in `MongoPreparedStatement`, but it might be a little bit more complex to enforce "deleting field if exists when updating its value to null".